### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/ServerlessRunFunction.js
+++ b/src/ServerlessRunFunction.js
@@ -17,6 +17,7 @@ export class ServerlessRunFunction {
             usage: 'Name of the function to run',
             required: true,
             shortcut: 'f',
+            type: 'string',
           },
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessRunFunction for "functionName"
```